### PR TITLE
Feature/yarn upgrade

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,7 +1,11 @@
 import { injectGlobal } from "styled-components";
 import { configure } from "@storybook/react";
 
-const req = require.context("../", true, /\.story\.js$/);
+const req = require.context(
+  "../",
+  true,
+  /^((?![\\/]node_modules).)*\.story\.js$/
+);
 
 function loadStories() {
   req.keys().forEach(filename => req(filename));

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
         - node_modules
 
 before_install:
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.0.2
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
     - lerna bootstrap
     - lerna link
     - npx flow-typed install
-    - yarn add -D jest
 
 script:
     - yarn lint

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.2.0",
+  "lerna": "2.4.0",
   "packages": ["packages/*"],
   "version": "independent",
   "command": {

--- a/package.json
+++ b/package.json
@@ -71,13 +71,13 @@
     "flow-typed": "^2.1.5",
     "jest": "^21.2.1",
     "jest-enzyme": "^4.0.0",
-    "lerna": "^2.3.1",
+    "lerna": "^2.4.0",
     "lint-staged": "^4.2.3",
     "prettier": "^1.7.4",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-test-renderer": "16",
+    "react-test-renderer": "^16.0.0",
     "styled-components": "^2.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5089,7 +5089,7 @@ lcov-parse@^0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
-lerna@^2.3.1:
+lerna@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.4.0.tgz#7b76446b154bafb9cba8996f3dc233f1cb6ca7c3"
   dependencies:
@@ -6802,7 +6802,7 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-test-renderer@16:
+react-test-renderer@^16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
   dependencies:


### PR DESCRIPTION
This patch upgrades yarn on travis, fix the storybook config to fix the import error on jest and removes the old workaround of installing jest again.

- closes #48 