### PR TITLE
[hoc-input] bugfix, value state could be replaced by an old property value when other property is set

### DIFF
--- a/packages/hoc-input/src/formInput.js
+++ b/packages/hoc-input/src/formInput.js
@@ -111,7 +111,10 @@ const formInput = WrappedComponent => {
     }
 
     componentWillReceiveProps(nextProps) {
-      const nextState = { value: nextProps.value || this.state.value };
+      const nextState = {};
+      if (nextProps.value !== this.props.value) {
+        nextState.value = nextProps.value;
+      }
       if (nextProps.validationMessages !== this.props.validationMessages) {
         nextState.validationMessages = nextProps.validationMessages;
       }

--- a/packages/hoc-input/src/formInput.test.js
+++ b/packages/hoc-input/src/formInput.test.js
@@ -10,7 +10,7 @@ describe("formInput", function() {
 
   const EnhancedInput = formInput(props => React.createElement("input", props));
   test("changing the validationMessages property after instantiation should update the validationMessages state and leave value state as it is", function() {
-    const component = shallow(<EnhancedInput value='some value'/>);
+    const component = shallow(<EnhancedInput value="some value" />);
     const state = component.state();
     expect(state.validationMessages.length).toBe(0);
 
@@ -21,15 +21,11 @@ describe("formInput", function() {
     expect(component.state()).toEqual(expectedState);
   });
 
-  test("sending the same validationMessages property should not update the validationMessages state", function() {
+  test("changing the value property should update value state", function() {
     const component = shallow(<EnhancedInput />);
     const state = component.state();
-    expect(state.validationMessages.length).toBe(0);
-    const validationMessages = ["foo", "bar"];
-    component.setProps({ validationMessages, value: "123" });
-
-    const expectedState = { ...state, validationMessages, value: "456" };
-    component.setProps({ validationMessages, value: "456" });
+    const expectedState = { ...state, value: "456" };
+    component.setProps({ value: "456" });
     expect(component.state()).toEqual(expectedState);
   });
 


### PR DESCRIPTION
fix(property): dont change value state when the changed property is not value

affects: @crave/farmblocks-hoc-input

ISSUES CLOSED: #188