### PR TITLE
Add option to don't show disabled tooltip

### DIFF
--- a/packages/hoc-disabled-tooltip/src/disabledTooltip.js
+++ b/packages/hoc-disabled-tooltip/src/disabledTooltip.js
@@ -8,6 +8,7 @@ import Wrapper from "./styledComponents/Wrapper";
 export const disabledTooltipProps = {
   displayBlock: PropTypes.bool,
   disabled: PropTypes.bool,
+  noTooltip: PropTypes.bool,
   tooltipAlign: PropTypes.oneOf(["left", "right"]),
   tooltipText: PropTypes.string,
   onMouseLeave: PropTypes.func,
@@ -28,7 +29,7 @@ function disabledTooltip(wrappedComponentType) {
     }
 
     onMouseOver(event) {
-      this.setState({ showTooltip: true });
+      this.setState({ showTooltip: !this.props.noTooltip });
       return this.props.onMouseOver(event);
     }
 
@@ -40,6 +41,7 @@ function disabledTooltip(wrappedComponentType) {
     render() {
       const {
         displayBlock,
+        noTooltip,
         tooltipAlign,
         tooltipText,
         ...wrappedComponentProps
@@ -79,6 +81,7 @@ function disabledTooltip(wrappedComponentType) {
       ...WrappedComponent.defaultProps,
       displayBlock: false,
       disabled: false,
+      noTooltip: false,
       onMouseOver: () => null,
       onMouseLeave: () => null,
       tooltipAlign: "left",

--- a/packages/hoc-disabled-tooltip/src/disabledTooltip.story.js
+++ b/packages/hoc-disabled-tooltip/src/disabledTooltip.story.js
@@ -65,4 +65,12 @@ storiesOf("HOC disabledTooltip", "module")
         tooltipText="A custom tooltip text"
       />
     ))
+  )
+  .add(
+    "no tooltip",
+    withInfo()(() => (
+      <EnhancedButton disabled noTooltip>
+        A disabled Button
+      </EnhancedButton>
+    ))
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,10 +91,6 @@
     "@crave/farmblocks-theme" "^1.5.0-alpha.dce1d648"
     object.values "^1.0.4"
 
-"@crave/farmblocks-theme@^1.5.0-alpha.d467d10d", "@crave/farmblocks-theme@^1.5.0-alpha.dce1d648":
-  version "1.5.0-alpha.ff765b02"
-  resolved "https://registry.yarnpkg.com/@crave/farmblocks-theme/-/farmblocks-theme-1.5.0-alpha.ff765b02.tgz#be938de48b68cc76e6d3850823cbc6c4f50b8410"
-
 "@hypnosphi/fuse.js@^3.0.9":
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/@hypnosphi/fuse.js/-/fuse.js-3.0.9.tgz#ea99f6121b4a8f065b4c71f85595db2714498807"


### PR DESCRIPTION
affects: `@crave/farmblocks-hoc-disabled-tooltip`

ISSUES CLOSED: #247