### PR TITLE
feat(tooltip): allow children to be rendered instead of only text

### DIFF
--- a/packages/tooltip/src/Tooltip.js
+++ b/packages/tooltip/src/Tooltip.js
@@ -7,9 +7,9 @@ const Tooltip = props => {
   const content = props.children || props.text;
   return (
     <Container>
-      <StyledTooltip {...props}>{content}</StyledTooltip>
+      {content && <StyledTooltip {...props}>{content}</StyledTooltip>}
     </Container>
-  )
+  );
 };
 
 Tooltip.propTypes = {

--- a/packages/tooltip/src/Tooltip.js
+++ b/packages/tooltip/src/Tooltip.js
@@ -3,14 +3,18 @@ import PropTypes from "prop-types";
 
 import { Container, StyledTooltip } from "./styledComponents/Tooltip";
 
-const Tooltip = props => (
-  <Container>
-    <StyledTooltip {...props}>{props.text}</StyledTooltip>
-  </Container>
-);
+const Tooltip = props => {
+  const content = props.children || props.text;
+  return (
+    <Container>
+      <StyledTooltip {...props}>{content}</StyledTooltip>
+    </Container>
+  )
+};
 
 Tooltip.propTypes = {
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
+  children: PropTypes.node,
   isVisible: PropTypes.bool,
   align: PropTypes.oneOf(["left", "right"]),
   zIndex: PropTypes.number

--- a/packages/tooltip/src/Tooltip.story.js
+++ b/packages/tooltip/src/Tooltip.story.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { storiesOf } from "@storybook/react";
-import Card from '@crave/farmblocks-card';
+import Card from "@crave/farmblocks-card";
 
 import Tooltip from "./Tooltip";
 
@@ -24,14 +24,12 @@ storiesOf("Tooltip", module)
   .add("with card", () => (
     <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
       <Tooltip isVisible={true}>
-        <Card>
-          this is a Card
-        </Card>
+        <Card>this is a Card</Card>
       </Tooltip>
     </div>
   ))
-  .add("empty", () => (
+  .add("without content", () => (
     <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
-      <Tooltip isVisible={true} />
+      <Tooltip />
     </div>
   ));

--- a/packages/tooltip/src/Tooltip.story.js
+++ b/packages/tooltip/src/Tooltip.story.js
@@ -1,22 +1,37 @@
 import React from "react";
 
 import { storiesOf } from "@storybook/react";
+import Card from '@crave/farmblocks-card';
 
 import Tooltip from "./Tooltip";
 
 storiesOf("Tooltip", module)
   .add("isVisible true - left aligned", () => (
     <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
-      <Tooltip isVisible text="Hey yo" />
+      <Tooltip isVisible text="This is a left aligned tooltip" />
     </div>
   ))
   .add("isVisible true - right aligned", () => (
     <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
-      <Tooltip isVisible text="Hey yo" align="right" />
+      <Tooltip isVisible text="This is a right aligned tooltip" align="right" />
     </div>
   ))
   .add("isVisible false", () => (
     <div style={{ position: "relative", width: "250px", border: "1px" }}>
       <Tooltip isVisible={false} text="Hey yo" />
+    </div>
+  ))
+  .add("with card", () => (
+    <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
+      <Tooltip isVisible={true}>
+        <Card>
+          this is a Card
+        </Card>
+      </Tooltip>
+    </div>
+  ))
+  .add("empty", () => (
+    <div style={{ position: "relative", width: "250px", border: "1px solid" }}>
+      <Tooltip isVisible={true} />
     </div>
   ));

--- a/packages/tooltip/src/styledComponents/Tooltip.js
+++ b/packages/tooltip/src/styledComponents/Tooltip.js
@@ -13,7 +13,7 @@ const StyledTooltip = styled.div`
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16);
   border: solid 1px rgba(0, 0, 0, 0.16);
   border-radius: 4px;
-  white-space: pre;
+  min-width: 15px;
   color: ${colors.CARBON};
 
   font-family: lato, sans-serif;

--- a/packages/tooltip/src/styledComponents/Tooltip.js
+++ b/packages/tooltip/src/styledComponents/Tooltip.js
@@ -13,6 +13,7 @@ const StyledTooltip = styled.div`
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16);
   border: solid 1px rgba(0, 0, 0, 0.16);
   border-radius: 4px;
+  white-space: pre;
   color: ${colors.CARBON};
 
   font-family: lato, sans-serif;

--- a/packages/tooltip/src/styledComponents/Tooltip.js
+++ b/packages/tooltip/src/styledComponents/Tooltip.js
@@ -13,7 +13,6 @@ const StyledTooltip = styled.div`
   box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16);
   border: solid 1px rgba(0, 0, 0, 0.16);
   border-radius: 4px;
-  min-width: 15px;
   color: ${colors.CARBON};
 
   font-family: lato, sans-serif;


### PR DESCRIPTION
affects: @crave/farmblocks-tooltip

ISSUES CLOSED: #285