### PR TITLE
Fix export path for Tag component

### DIFF
--- a/packages/tag/src/index.js
+++ b/packages/tag/src/index.js
@@ -1,1 +1,1 @@
-export { default } from "components/Tag";
+export { default } from "./components/Tag";

--- a/yarn.lock
+++ b/yarn.lock
@@ -62,6 +62,16 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@crave/farmblocks-dev-scaffold@^0.2.0-alpha.05aa3a60":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@crave/farmblocks-dev-scaffold/-/farmblocks-dev-scaffold-0.2.0.tgz#9c2b899ea521a2fdf38557c7d44745705301f54b"
+  dependencies:
+    inquirer "^4.0.0"
+    prettier "^1.7.4"
+    shelljs "^0.8.0"
+    slug "^0.9.1"
+    uppercamelcase "^3.0.0"
+
 "@crave/farmblocks-hoc-disabled-tooltip@^0.3.0-alpha.da3401b7":
   version "0.3.0-alpha.da3401b7"
   resolved "https://registry.yarnpkg.com/@crave/farmblocks-hoc-disabled-tooltip/-/farmblocks-hoc-disabled-tooltip-0.3.0-alpha.da3401b7.tgz#6afb486dfeb0978630c73e872b8479cbb4313373"


### PR DESCRIPTION
affects: `@crave/farmblocks-tags`

ISSUES CLOSED: #303