### PR TITLE
fix(map-balloon): fix pin shadow on IE11

### DIFF
--- a/packages/map-balloon/src/styledComponents/Pin.js
+++ b/packages/map-balloon/src/styledComponents/Pin.js
@@ -13,7 +13,7 @@ const Pin = styled.div`
 
   color: ${props => props.pinColor};
 
-  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.24));
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.24);
 `;
 Pin.propTypes = {
   highlighted: PropTypes.bool


### PR DESCRIPTION
affects: @crave/farmblocks-map-balloon

ISSUES CLOSED: #364