### PR TITLE
fix: updated styled-components to 3.4.9 peer-dependency on all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "react-test-renderer": "^16.4.0",
     "recompose": "^0.30.0",
     "snyk": "^1.82.1",
-    "styled-components": "^3.3.2"
+    "styled-components": "^3.4.9"
   },
   "resolutions": {
     "ua-parser-js": "^0.7.18",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -33,7 +27,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "keywords": [
     "farmblocks",

--- a/packages/amount-selectors/package.json
+++ b/packages/amount-selectors/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "selector",
-    "amount"
-  ],
+  "keywords": ["selector", "amount"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -37,12 +31,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
-  "keywords": [
-    "farmblocks",
-    "button",
-    "react",
-    "component"
-  ]
+  "keywords": ["farmblocks", "button", "react", "component"]
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "devDependencies": {
     "@crave/farmblocks-empty-state": "^2.0.2"

--- a/packages/carousel/package.json
+++ b/packages/carousel/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-image": "^0.4.4",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,13 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "dropdown"
-  ],
+  "keywords": ["dropdown"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/empty-state/package.json
+++ b/packages/empty-state/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -39,7 +33,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/filter-popover/package.json
+++ b/packages/filter-popover/package.json
@@ -1,14 +1,12 @@
 {
   "name": "@crave/farmblocks-filter-popover",
   "version": "0.2.0",
-  "description": "A farmblocks-popover with farmblocks-form-wrapper as the content#520",
+  "description":
+    "A farmblocks-popover with farmblocks-form-wrapper as the content#520",
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +22,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "filter",
-    "popover"
-  ],
+  "keywords": ["filter", "popover"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/form-wrapper/package.json
+++ b/packages/form-wrapper/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,21 +21,17 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",
     "@crave/farmblocks-link": "^3.1.0",
     "@crave/farmblocks-text": "^2.0.0",
-    "@crave/farmblocks-theme": "^1.6.0",
-    "styled-components": "^3.4.6"
+    "@crave/farmblocks-theme": "^1.6.0"
   },
   "devDependencies": {
     "@crave/farmblocks-input-text": "^3.1.2"

--- a/packages/hoc-disabled-tooltip/package.json
+++ b/packages/hoc-disabled-tooltip/package.json
@@ -1,14 +1,12 @@
 {
   "name": "@crave/farmblocks-hoc-disabled-tooltip",
   "version": "1.1.9",
-  "description": "A Higher Order Component that adds the behaviour of displaying a tooltip when a component is disabled (disabled property true)",
+  "description":
+    "A Higher Order Component that adds the behaviour of displaying a tooltip when a component is disabled (disabled property true)",
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,15 +22,12 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "recompose": "^0.26.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-tooltip": "^0.8.1"

--- a/packages/hoc-input/package.json
+++ b/packages/hoc-input/package.json
@@ -1,14 +1,12 @@
 {
   "name": "@crave/farmblocks-hoc-input",
   "version": "4.1.1",
-  "description": "A High Order Component that adds behaviour of label support, different styles for focus and errors, and validation error messages.",
+  "description":
+    "A High Order Component that adds behaviour of label support, different styles for focus and errors, and validation error messages.",
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,15 +22,12 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "recompose": "^0.26.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-image": "^0.4.4",

--- a/packages/hoc-validation-messages/package.json
+++ b/packages/hoc-validation-messages/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-image": "^0.4.4",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "repository": "https://github.com/CraveFood/farmblocks",
   "publishConfig": {
     "access": "public"
@@ -23,7 +17,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-theme": "^1.6.0"

--- a/packages/input-checkbox/package.json
+++ b/packages/input-checkbox/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,18 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react",
-    "widget",
-    "checkbox",
-    "form",
-    "input"
-  ],
+  "keywords": ["farmblocks", "react", "widget", "checkbox", "form", "input"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-hoc-disabled-tooltip": "^1.1.9",

--- a/packages/input-radio/package.json
+++ b/packages/input-radio/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,11 +21,7 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "radio",
-    "form",
-    "input"
-  ],
+  "keywords": ["radio", "form", "input"],
   "dependencies": {
     "@crave/farmblocks-hoc-disabled-tooltip": "^1.1.9",
     "@crave/farmblocks-text": "^2.0.0",
@@ -37,6 +30,6 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   }
 }

--- a/packages/input-select/package.json
+++ b/packages/input-select/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,17 +21,12 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "select",
-    "selectbox",
-    "form",
-    "input"
-  ],
+  "keywords": ["select", "selectbox", "form", "input"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "recompose": "^0.26.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-card": "^0.6.4",

--- a/packages/input-text/package.json
+++ b/packages/input-text/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,15 +21,12 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "recompose": "^0.26.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/link/package.json
+++ b/packages/link/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "repository": "https://github.com/CraveFood/farmblocks",
   "publishConfig": {
     "access": "public"
@@ -23,7 +17,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-hoc-disabled-tooltip": "^1.1.9",

--- a/packages/map-balloon/package.json
+++ b/packages/map-balloon/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,14 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react"
-  ],
+  "keywords": ["farmblocks", "react"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-card": "^0.6.4",

--- a/packages/more-info/package.json
+++ b/packages/more-info/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,15 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react",
-    "tooltip"
-  ],
+  "keywords": ["farmblocks", "react", "tooltip"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-text": "^2.0.0",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,13 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "popover"
-  ],
+  "keywords": ["popover"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-tooltip": "^0.8.1",

--- a/packages/scaffold/src/templates/package.js
+++ b/packages/scaffold/src/templates/package.js
@@ -3,7 +3,7 @@ const { format } = require("prettier");
 const peerDependencies = {
   react: "^16.0.0",
   "prop-types": "^15.6.0",
-  "styled-components": "^3.0.2"
+  "styled-components": "^3.4.9"
 };
 
 const packageTemplate = ({

--- a/packages/search-field/package.json
+++ b/packages/search-field/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,16 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "farmblocks",
-    "react",
-    "search",
-    "input"
-  ],
+  "keywords": ["farmblocks", "react", "search", "input"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-dropdown": "^0.8.4",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -33,15 +27,9 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
-  "keywords": [
-    "farmblocks",
-    "react",
-    "component",
-    "stepper",
-    "widget"
-  ],
+  "keywords": ["farmblocks", "react", "component", "stepper", "widget"],
   "dependencies": {
     "@crave/farmblocks-theme": "^1.6.0"
   }

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -35,7 +32,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-button": "^5.1.0",

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -5,10 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "lib"
-  ],
+  "files": ["AUTHORS", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -24,13 +21,11 @@
     "url": "https://github.com/CraveFood/farmblocks/issues"
   },
   "homepage": "https://github.com/CraveFood/farmblocks#readme",
-  "keywords": [
-    "tag"
-  ],
+  "keywords": ["tag"],
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "dependencies": {
     "@crave/farmblocks-theme": "^1.6.0",

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -30,7 +24,7 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
   "keywords": [
     "farmblocks",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -5,13 +5,7 @@
   "author": "Crave Food Systems and AUTHORS",
   "license": "MIT",
   "main": "lib/index.js",
-  "files": [
-    "AUTHORS",
-    "LICENSE",
-    "README.md",
-    "CHANGELOG.md",
-    "lib"
-  ],
+  "files": ["AUTHORS", "LICENSE", "README.md", "CHANGELOG.md", "lib"],
   "publishConfig": {
     "access": "public"
   },
@@ -33,14 +27,9 @@
   "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
-    "styled-components": "^3.0.2"
+    "styled-components": "^3.4.9"
   },
-  "keywords": [
-    "farmblocks",
-    "tooltip",
-    "react",
-    "component"
-  ],
+  "keywords": ["farmblocks", "tooltip", "react", "component"],
   "dependencies": {
     "@crave/farmblocks-theme": "^1.6.0",
     "object.values": "^1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9523,9 +9523,9 @@ style-loader@^0.20.3:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
-styled-components@^3.3.2, styled-components@^3.4.6:
-  version "3.4.6"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.6.tgz#134f1ab89ed732686bf7de3ff8fca557283cbd60"
+styled-components@^3.4.9:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.9.tgz#519abeb351b37be5b7de6a15ff9e4efeb9d772da"
   dependencies:
     buffer "^5.0.3"
     css-to-react-native "^2.0.3"


### PR DESCRIPTION
affects: @crave/farmblocks-alert, @crave/farmblocks-amount-selectors, @crave/farmblocks-button,
@crave/farmblocks-card, @crave/farmblocks-carousel, @crave/farmblocks-dropdown,
@crave/farmblocks-empty-state, @crave/farmblocks-filter-popover, @crave/farmblocks-form-wrapper,
@crave/farmblocks-hoc-disabled-tooltip, @crave/farmblocks-hoc-input,
@crave/farmblocks-hoc-validation-messages, @crave/farmblocks-image,
@crave/farmblocks-input-checkbox, @crave/farmblocks-input-radio, @crave/farmblocks-input-select,
@crave/farmblocks-input-text, @crave/farmblocks-link, @crave/farmblocks-map-balloon,
@crave/farmblocks-more-info, @crave/farmblocks-popover, @crave/farmblocks-dev-scaffold,
@crave/farmblocks-search-field, @crave/farmblocks-stepper, @crave/farmblocks-table,
@crave/farmblocks-tags, @crave/farmblocks-text, @crave/farmblocks-tooltip

## Closes Issues

* Closes #547

## Code review checklist

### Reviewer 1

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs

### Reviewer 2

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs
