### PR TITLE
Remove travis node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ---
 sudo: false
 language: node_js
-node_js:
-  - "12.1.0"
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
I pushed some tests commits to check the node version and it is working as expected:

## Using 12.1.0
https://travis-ci.org/CraveFood/farmblocks/builds/599361753

![image](https://user-images.githubusercontent.com/9268203/67049053-b9768f80-f10b-11e9-8d04-b4fd8d0dab4c.png)


## Using 12.0.0 (for testing purposes)

https://travis-ci.org/CraveFood/farmblocks/builds/599362461

![image](https://user-images.githubusercontent.com/9268203/67049102-d6ab5e00-f10b-11e9-9184-79a2c0969fef.png)


## Closes Issues

* Closes #857

## Code review checklist

### Reviewer 1

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs

### Reviewer 2

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs
