### PR TITLE
[EmptyState] Fix Icon proptype

### DIFF
--- a/packages/empty-state/src/EmptyState.js
+++ b/packages/empty-state/src/EmptyState.js
@@ -66,7 +66,7 @@ EmptyState.propTypes = {
     }),
   ),
   info: PropTypes.string,
-  icon: PropTypes.string,
+  icon: PropTypes.node,
   className: PropTypes.string,
 };
 


### PR DESCRIPTION
affects: @crave/farmblocks-empty-state

## Closes Issues

* Closes #952

## Code review checklist

### Reviewer 1

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs

### Reviewer 2

* [ ] Functions properly
* [ ] Good readability, clarity and overall quality
* [ ] Has tests
* [ ] Has docs
